### PR TITLE
Passthrough for zstd window size argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Created files will follow the structure ``{output_path}original_filename_without
 | ``--pattern`` | The regex pattern to be applied line-by-line. A match means the line will be included in the output. Keep in mind that regex terms with special characters need to be escaped properly. Look-around are not supported in favor of a worst case performance of [O(m * n)](https://docs.rs/regex/latest/regex/). Also note [the impact of regex patterns on your performance](https://docs.rs/regex/latest/regex/#performance). | ``^`` matches everything |
 | ``--threads`` | The maximum number of threads used by rayon. Since each thread reads from one file, changing this number also affects I/O.  | ``0`` unlimited |
 | ``--buffer`` | The maximum buffer per thread before matches lines are written to disk. | ``4096`` 4KiB |
+| ``--window-log-max`` | $\text{log}_2$ bytes as the maximum window size for zstd decoding (equivalent to --long parameter in zstd). | ``27`` ($2^{27}$ bytes $\approx$ 134MB) |
 |``--quiet``| Displays only the current progress and error messages. | ``false`` |
 |``--no-write``| Does not write any output files. Can be used for testing or line counting. It will check for already existing output files so you can spot conflicts before running long tasks. | ``false`` |
 
@@ -94,6 +95,7 @@ no_write = false
 # In this example we the output to be uncompressed thus we set zstd to false
 zstd = false
 compression_level = 0
+window_log_max = 27
 
 # Regex Filter
 pattern = ',"mode":62,' # Make sure to properly escape if needed, look-arounds are not supported
@@ -144,6 +146,10 @@ Although zstd-jsonl-filter is usually CPU bound when reading from an NVMe, that 
 
 Write speeds depend on how many entries are filtered, your storage speed and if compression is used.
 By default zstd-jsonl-filter writes to a 4 KiB buffer which you can adjust as needed.
+
+### Window log max
+
+Some zstd archives are compressed using large window sizes that exceed the default decompression limits. The `--window-log-max` parameter controls the maximum memory window size used during zstd decompression; it is equivalent to `--long` in zstd. Increase this value if you experience `"Frame requires too much memory for decoding"` errors.
 
 # Donate
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -665,7 +665,7 @@ struct Cli {
     quiet: bool,
     #[arg(long = "config", default_value = "config.toml")]
     config: String,
-    #[arg(long = "window-log-max", help = "Maximum window log size for zstd decoding (equivalent to --long parameter)", default_value = "27")]
+    #[arg(long = "window-log-max", help = "Maximum window log size for zstd decoding (equivalent to --long parameter)")]
     window_log_max: Option<u32>,
 }
 
@@ -806,7 +806,7 @@ fn set_config() -> Config {
     let window_log_max = cli
         .window_log_max
         .or_else(|| config.as_ref().map(|c| c.window_log_max))
-        .unwrap_or_else(|| fallback_window_log_max);
+        .unwrap_or(fallback_window_log_max);
 
     // Validate the regex pattern.
     let _ = match validate_regex(&pattern) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -311,7 +311,9 @@ fn read_lines(
     }
     let file = File::open(input_file_path)?;
 
-    let decoder = Decoder::new(file)?;
+    // Create decoder with custom window log max
+    let mut decoder = Decoder::new(file)?;
+    decoder.window_log_max(config.window_log_max)?;
     let reader = BufReader::new(decoder);
 
     // Measure the size of decompressed data
@@ -663,6 +665,8 @@ struct Cli {
     quiet: bool,
     #[arg(long = "config", default_value = "config.toml")]
     config: String,
+    #[arg(long = "window-log-max", help = "Maximum window log size for zstd decoding (equivalent to --long parameter)", default_value = "27")]
+    window_log_max: Option<u32>,
 }
 
 // Internal and config.toml structure
@@ -679,6 +683,7 @@ struct Config {
     buffer: usize,
     no_write: bool,
     quiet: bool,
+    window_log_max: u32,
 }
 
 fn validate_regex(pattern: &str) -> Result<Regex, String> {
@@ -705,6 +710,7 @@ fn set_config() -> Config {
     let fallback_buffer = 4096; // the buffer size after which data is written to disk, here: 4KiB
     let fallback_no_write = false; // do not write to output
     let fallback_quiet = false;
+    let fallback_window_log_max = 27; // Default window log max (equivalent to zstd default)
 
     // Parse command-line arguments.
     let cli = Cli::parse();
@@ -796,6 +802,12 @@ fn set_config() -> Config {
             .and_then(|c| Some(c.quiet))
             .unwrap_or(fallback_quiet);
 
+    // Window log max for zstd decoding
+    let window_log_max = cli
+        .window_log_max
+        .or_else(|| config.as_ref().map(|c| c.window_log_max))
+        .unwrap_or_else(|| fallback_window_log_max);
+
     // Validate the regex pattern.
     let _ = match validate_regex(&pattern) {
         Ok(r) => r,
@@ -824,5 +836,6 @@ fn set_config() -> Config {
         buffer: buffer,
         no_write: no_write,
         quiet: quiet,
+        window_log_max: window_log_max,
     }
 }


### PR DESCRIPTION
Hi,

Thanks for putting this script together. Its been a huge help filtering down reddit pushshift data.

For some files, they use a really high blocksize for zstd compression which breaks almost every package that offers streaming zstd decompression. The solution is pretty easy but packages don't give the user access to the necessary param to resolve it. I just added a cli-arg to control the zstd memory window size.

I implemented the same fix in ugrep and compared the runtime of the two and this script won quite handily - this was not a particularly scientific measurement mind:
```bash
# Final progress bar showed 53 mins
$ ./zstd-jsonl-filter --window-log-max 31 --pattern "\b(?i)national\s+gallery\b" --input grouped-by-month/submissions/ --output grouped-by-month/submissions/
```

```bash
$ time ./ugrep/src/ugrep -z --zstd-long=31 -i '\bnational\s+gallery\b' grouped-by-month/submissions/ > grouped-by-month/submissions_ng.txt
real	69m16.824s
user	169m6.307s
sys	112m2.874s
```
All tests run on an old Ryzen 3 3300x and a Samsung QVO 870.

Feel free to reject but I thought I'd share in-case its useful.